### PR TITLE
Update GraphQL request to use POST after One Pace website v2.5.0

### DIFF
--- a/JWueller.Jellyfin.OnePace.Tests/WebRepositoryTests.cs
+++ b/JWueller.Jellyfin.OnePace.Tests/WebRepositoryTests.cs
@@ -225,8 +225,11 @@ public class WebRepositoryTests
                             Content = new StringContent(MetadataDeResponse),
                         });
                     }
+                }
 
-                    if (request.RequestUri.AbsoluteUri.StartsWith("https://onepace.net/api/graphql") && request.RequestUri.Query.Contains("databaseGetAllArcs"))
+                if (request.RequestUri != null && request.Method == HttpMethod.Post)
+                {
+                    if (request.RequestUri.AbsoluteUri.StartsWith("https://onepace.net/api/graphql") && request.Content != null && request.Content.ReadAsStringAsync(_).Result.Contains("databaseGetAllArcs"))
                     {
                         return Task.FromResult(new HttpResponseMessage
                         {


### PR DESCRIPTION
Seems like after version 2.5.0 of the One Pace website, the GraphQL backend has been updated to use POST requests instead of GET requests.